### PR TITLE
Replaced /titanium﻿ with /platform﻿ in URLs

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -10,7 +10,7 @@ This module requires Titanium 3.1.2 or greater.
 
 ## Getting Started
 
-View the [Using Titanium Modules](http://docs.appcelerator.com/titanium/latest/#!/guide/Using_Titanium_Modules) document for instructions on getting started with using this module in your application.
+View the [Using Titanium Modules](http://docs.appcelerator.com/platform/latest/#!/guide/Using_Titanium_Modules) document for instructions on getting started with using this module in your application.
 
 ## Accessing the Module
 


### PR DESCRIPTION
Replaced any links to `../titanium/...` with `../platform/..`

https://jira.appcelerator.org/browse/MOD-2124