### PR TITLE
Replaced /titanium﻿ with /platform﻿ in URLs

### DIFF
--- a/example/Basic/app.js
+++ b/example/Basic/app.js
@@ -324,7 +324,7 @@ function showNotification(params) {
             // className : 'com.appcelerator.test.Test7Activity',
      
             // if you use url, you need to make some changes to your tiapp.xml
-            // SEE: http://docs.appcelerator.com/titanium/latest/#!/guide/Android_Notifications-section-29004809_AndroidNotifications-Usingtheurlproperty
+            // SEE: http://docs.appcelerator.com/platform/latest/#!/guide/Android_Notifications-section-29004809_AndroidNotifications-Usingtheurlproperty
             url: 'app.js',
             flags: Ti.Android.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED | Ti.Android.FLAG_ACTIVITY_SINGLE_TOP
         });


### PR DESCRIPTION
Replaced any links to `../titanium/...` with `../platform/..`

https://jira.appcelerator.org/browse/MOD-2124